### PR TITLE
Add build job to CI

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -37,3 +37,19 @@ jobs:
 
             - name: Run tests
               run: yarn test
+              
+    build:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+
+            - uses: actions/setup-node@v4
+              with:
+                  cache: yarn
+
+            - name: Install modules
+              run: yarn install --frozen-lockfile
+
+            - name: Run build
+              run: yarn run build
+

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -3,9 +3,6 @@ on:
     push:
         branches:
             - "*"
-    pull_request:
-        branches:
-            - main
 
 jobs:
     check-formatting:


### PR DESCRIPTION
Adds a job to our testing workflow to verify that the project builds successfully and types are all correct before merging PRs.