### PR TITLE
Change manual movement logic, add power level sliders

### DIFF
--- a/src/client/debug/drive-robot.tsx
+++ b/src/client/debug/drive-robot.tsx
@@ -85,12 +85,18 @@ export function DriveRobot(props: DriveRobotProps) {
         setPower({ left: -0.5, right: 0.5 });
     }, []);
 
-    const handleLeftPowerChange = useCallback((value: number) => {
-        setPower({ left: value, right: power.right });
-    }, []);
-    const handleRightPowerChange = useCallback((value: number) => {
-        setPower({ left: power.left, right: value });
-    }, []);
+    const handleLeftPowerChange = useCallback(
+        (value: number) => {
+            setPower({ left: value, right: power.right });
+        },
+        [power.right],
+    );
+    const handleRightPowerChange = useCallback(
+        (value: number) => {
+            setPower({ left: power.left, right: value });
+        },
+        [power.left],
+    );
 
     const hotkeys = useMemo(
         () => [

--- a/src/client/debug/drive-robot.tsx
+++ b/src/client/debug/drive-robot.tsx
@@ -1,5 +1,5 @@
 import { Button, useHotkeys, Slider } from "@blueprintjs/core";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState, Dispatch } from "react";
 import { DriveRobotMessage } from "../../common/message/drive-robot-message";
 import { SendMessage } from "../../common/message/message";
 
@@ -12,8 +12,8 @@ function useManualMoveHandler(
     //useManualMoveHandler takes in the state powers and the setPowers functions, and returns a function that sets the power levels in the state.
     leftPower: number,
     rightPower: number,
-    setLeftPower: React.Dispatch<React.SetStateAction<number>>,
-    setRightPower: React.Dispatch<React.SetStateAction<number>>,
+    setLeftPower: Dispatch<number>,
+    setRightPower: Dispatch<number>,
 ) {
     const handleManualMove = useCallback(() => {
         setLeftPower(leftPower);

--- a/src/client/debug/drive-robot.tsx
+++ b/src/client/debug/drive-robot.tsx
@@ -8,6 +8,9 @@ interface DriveRobotProps {
     sendMessage: SendMessage;
 }
 
+const approxeq = (v1: number, v2: number, epsilon = 0.001) =>
+    Math.abs(v1 - v2) <= epsilon;
+
 /**
  * A component which can be used to drive an individual robot around.
  */
@@ -19,7 +22,10 @@ export function DriveRobot(props: DriveRobotProps) {
 
     //useEffect hook to send the power levels to the robot if there is a change in the power levels
     useEffect(() => {
-        if (prev.left === power.left && prev.right === power.right) {
+        if (
+            approxeq(prev.left, power.left) &&
+            approxeq(prev.right, power.right)
+        ) {
             return;
         }
         props.sendMessage(

--- a/src/client/debug/drive-robot.tsx
+++ b/src/client/debug/drive-robot.tsx
@@ -1,23 +1,11 @@
 import { Button, useHotkeys, Slider } from "@blueprintjs/core";
-import { useCallback, useEffect, useMemo, useState, Dispatch } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { DriveRobotMessage } from "../../common/message/drive-robot-message";
 import { SendMessage } from "../../common/message/message";
 
 interface DriveRobotProps {
     robotId: string;
     sendMessage: SendMessage;
-}
-
-function useManualMoveHandler(
-    //useManualMoveHandler takes in the state powers and the setPowers functions, and returns a function that sets the power levels in the state.
-    leftPower: number,
-    rightPower: number,
-    setPower: Dispatch<{ left: number; right: number }>,
-) {
-    const handleManualMove = useCallback(() => {
-        setPower({ left: leftPower, right: rightPower });
-    }, [leftPower, rightPower, setPower]);
-    return handleManualMove;
 }
 
 /**
@@ -84,17 +72,25 @@ export function DriveRobot(props: DriveRobotProps) {
         setPower({ left: 0, right: 0 });
     }, []);
 
-    const handleDriveForward = useManualMoveHandler(1, 1, setPower);
-    const handleDriveBackward = useManualMoveHandler(-1, -1, setPower);
-    const handleTurnRight = useManualMoveHandler(0.5, -0.5, setPower);
-    const handleTurnLeft = useManualMoveHandler(-0.5, 0.5, setPower);
+    const handleDriveForward = useCallback(() => {
+        setPower({ left: 1, right: 1 });
+    }, []);
+    const handleDriveBackward = useCallback(() => {
+        setPower({ left: -1, right: -1 });
+    }, []);
+    const handleTurnRight = useCallback(() => {
+        setPower({ left: 0.5, right: -0.5 });
+    }, []);
+    const handleTurnLeft = useCallback(() => {
+        setPower({ left: -0.5, right: 0.5 });
+    }, []);
 
-    const handleLeftPowerChange = (value: number) => {
+    const handleLeftPowerChange = useCallback((value: number) => {
         setPower({ left: value, right: power.right });
-    };
-    const handleRightPowerChange = (value: number) => {
+    }, []);
+    const handleRightPowerChange = useCallback((value: number) => {
         setPower({ left: power.left, right: value });
-    };
+    }, []);
 
     const hotkeys = useMemo(
         () => [

--- a/src/client/debug/drive-robot.tsx
+++ b/src/client/debug/drive-robot.tsx
@@ -8,7 +8,7 @@ interface DriveRobotProps {
     sendMessage: SendMessage;
 }
 
-const approxeq = (v1: number, v2: number, epsilon = 0.001) =>
+const approxeq = (v1: number, v2: number, epsilon = 0.01) =>
     Math.abs(v1 - v2) <= epsilon;
 
 /**


### PR DESCRIPTION
Added power sliders that dynamically update
depending on the power levels of the robots.

This change updates the method of how we send
messages to the robots. We now update the state
with the different input methods, and if
the state changes, we send the message to the robot. This allows us to ignore if the powerlevel is the same as the previous one. Reduces message spam.