### PR TITLE
Move methods

### DIFF
--- a/src/common/chess-engine.ts
+++ b/src/common/chess-engine.ts
@@ -91,6 +91,7 @@ export class ChessEngine {
             return undefined;
         }
     }
+    //returns the side of the piece if there is a piece on the square
     getPieceSide(square: Square): Side | undefined {
         const piece = this.chess.get(square);
         if (piece !== null) {
@@ -111,11 +112,6 @@ export class ChessEngine {
     getPieceTypeFromMove(move: Move) {
         return this.getPieceTypeFromSquare(move.from) as PieceType;
     }
-
-    /**
-     * Takes a move argument and returns the piece that is moving as a PieceType enum
-     *
-     */
 
     getLegalMoves(square?: Square) {
         return this.chess.moves({

--- a/src/common/chess-engine.ts
+++ b/src/common/chess-engine.ts
@@ -47,6 +47,11 @@ export class ChessEngine {
         return moves.length > 0 ? moves[moves.length - 1] : undefined;
     }
 
+    /**
+     * Takes a move argument and determines if the move is a King Side Castle.
+     * Assumes that chess hasn't been updated yet
+     * @returns true if the move is a King Side Castle
+     */
     isKingSideCastling(move: Move) {
         if (this.getPieceTypeFromSquare(move.from) !== PieceType.KING) {
             return false;
@@ -57,6 +62,11 @@ export class ChessEngine {
         }
     }
 
+    /**
+     * Takes a move argument and determines if the move is an En Passant Capture.
+     * Assumes that chess hasn't been updated yet
+     * @returns true if the move is an En Passant Capture
+     */
     isEnPassant(move: Move) {
         if (
             move.from[0] !== move.to[0] &&
@@ -68,10 +78,20 @@ export class ChessEngine {
         }
     }
 
+    /**
+     * Takes a move argument and determines if the move results in a capture
+     * Assumes that chess hasn't been updated yet
+     * @returns true if the move is a Capture
+     */
     isCapture(move: Move) {
         return this.hasPiece(move.to);
     }
 
+    /**
+     * Takes a move argument and determines if the move is a Queen Side Castle.
+     * Assumes that chess hasn't been updated yet
+     * @returns true if the move is a Queen Side Castle
+     */
     isQueenSideCastling(move: Move) {
         if (this.getPieceTypeFromSquare(move.from) !== PieceType.KING) {
             return false;
@@ -82,7 +102,10 @@ export class ChessEngine {
         }
     }
 
-    //returns the PieceType of the of the piece on the square or undefined
+    /**
+     * Takes in a Square argument and returns the piece on the square or undefined
+     * @returns The current piece on the square as a PieceType enum or undefined if there is no piece
+     */
     getPieceTypeFromSquare(square: Square): PieceType | undefined {
         const piece = this.chess.get(square);
         if (piece !== null) {
@@ -91,7 +114,11 @@ export class ChessEngine {
             return undefined;
         }
     }
-    //returns the side of the piece if there is a piece on the square
+
+    /**
+     * Takes in a Square argument and returns the side of the piece on the square or undefined
+     * @returns The current side of the piece on the square or undefined if there is no piece on the square
+     */
     getPieceSide(square: Square): Side | undefined {
         const piece = this.chess.get(square);
         if (piece !== null) {
@@ -101,13 +128,17 @@ export class ChessEngine {
         }
     }
 
+    /**
+     * Takes in a Square argument and returns if the square has a piece on it.
+     * @returns true if the square has a piece on it.
+     */
     hasPiece(square: Square) {
         return this.getPieceTypeFromSquare(square) !== undefined;
     }
 
     /**
-     * Takes a move argument and returns the piece that is moving as a PieceType enum
-     *
+     * Takes in a Move argument and returns the piece on the square
+     * @returns The current piece on the square as a PieceType enum
      */
     getPieceTypeFromMove(move: Move) {
         return this.getPieceTypeFromSquare(move.from) as PieceType;
@@ -135,6 +166,7 @@ export class ChessEngine {
 
     /**
      * Returns true if a move is a promotion, and false otherwise.
+     * Assumes that chess hasn't been updated yet
      */
     checkPromotion(from: Square, to: Square): boolean {
         if (this.getPieceTypeFromSquare(from) !== PieceType.PAWN) {

--- a/src/common/chess-engine.ts
+++ b/src/common/chess-engine.ts
@@ -47,8 +47,43 @@ export class ChessEngine {
         return moves.length > 0 ? moves[moves.length - 1] : undefined;
     }
 
+    isKingSideCastling(move: Move) {
+        if (this.getPieceTypeFromSquare(move.from) !== PieceType.KING) {
+            return false;
+        } else if (this.chess.get(move.from).color === Side.WHITE) {
+            return move.from === "e1" && move.to === "g1";
+        } else {
+            return move.from === "e8" && move.to === "g8";
+        }
+    }
+
+    isEnPassant(move: Move) {
+        if (
+            move.from[0] !== move.to[0] &&
+            this.getPieceTypeFromSquare(move.from) === PieceType.PAWN
+        ) {
+            return !this.hasPiece(move.to);
+        } else {
+            return false;
+        }
+    }
+
+    isCapture(move: Move) {
+        return this.hasPiece(move.to);
+    }
+
+    isQueenSideCastling(move: Move) {
+        if (this.getPieceTypeFromSquare(move.from) !== PieceType.KING) {
+            return false;
+        } else if (this.chess.get(move.from).color === Side.WHITE) {
+            return move.from === "e1" && move.to === "c1";
+        } else {
+            return move.from === "e8" && move.to === "c8";
+        }
+    }
+
     //returns the PieceType of the of the piece on the square or undefined
-    getPieceType(square: Square): PieceType | undefined {
+    getPieceTypeFromSquare(square: Square): PieceType | undefined {
         const piece = this.chess.get(square);
         if (piece !== null) {
             return piece.type as PieceType;
@@ -66,7 +101,15 @@ export class ChessEngine {
     }
 
     hasPiece(square: Square) {
-        return this.getPieceType(square) !== undefined;
+        return this.getPieceTypeFromSquare(square) !== undefined;
+    }
+
+    /**
+     * Takes a move argument and returns the piece that is moving as a PieceType enum
+     *
+     */
+    getPieceTypeFromMove(move: Move) {
+        return this.getPieceTypeFromSquare(move.from) as PieceType;
     }
 
     getLegalMoves(square?: Square) {
@@ -93,7 +136,7 @@ export class ChessEngine {
      * Returns true if a move is a promotion, and false otherwise.
      */
     checkPromotion(from: Square, to: Square): boolean {
-        if (this.getPieceType(from) !== PieceType.PAWN) {
+        if (this.getPieceTypeFromSquare(from) !== PieceType.PAWN) {
             return false;
         } else if (this.chess.get(from).color === Side.WHITE) {
             return from[1] === "7" && to[1] === "8";


### PR DESCRIPTION
Added checking methods to chess engine for different types of move such as castling or captures. Changed getPiece to getPieceTypeFromSquare, and a second method getPieceTypeFromMove taking a square or move as an argument to return the piece on the square. 