### PR TITLE
Change RelativeMove back to turnAndDrive

### DIFF
--- a/src/server/command/move-command.ts
+++ b/src/server/command/move-command.ts
@@ -87,7 +87,10 @@ export class RotateToStartCommand extends RobotCommand {
  *
  * Distance may be negative, indicating the robot drives backwards.
  */
-export class DriveCommand extends RobotCommand implements Reversible<DriveCommand> {
+export class DriveCommand
+    extends RobotCommand
+    implements Reversible<DriveCommand>
+{
     constructor(
         robotId: string,
         public tileDistance: number,
@@ -101,10 +104,7 @@ export class DriveCommand extends RobotCommand implements Reversible<DriveComman
     }
 
     public reverse(): DriveCommand {
-        return new DriveCommand(
-            this.robotId,
-            -this.tileDistance,
-        );
+        return new DriveCommand(this.robotId, -this.tileDistance);
     }
 }
 

--- a/src/server/command/move-command.ts
+++ b/src/server/command/move-command.ts
@@ -83,9 +83,11 @@ export class RotateToStartCommand extends RobotCommand {
 }
 
 /**
- * Drives a robot for a distance equal to a number of tiles.
+ * Drives a robot for a distance equal to a number of tiles. Distance
+ * may be negative, indicating the robot drives backwards.
  *
- * Distance may be negative, indicating the robot drives backwards.
+ * Does not modify robot's stored position, must be done on the
+ * caller's side.
  */
 export class DriveCommand
     extends RobotCommand

--- a/src/server/command/move-command.ts
+++ b/src/server/command/move-command.ts
@@ -83,6 +83,32 @@ export class RotateToStartCommand extends RobotCommand {
 }
 
 /**
+ * Drives a robot for a distance equal to a number of tiles.
+ *
+ * Distance may be negative, indicating the robot drives backwards.
+ */
+export class DriveCommand extends RobotCommand implements Reversible<DriveCommand> {
+    constructor(
+        robotId: string,
+        public tileDistance: number,
+    ) {
+        super(robotId);
+    }
+
+    public async execute(): Promise<void> {
+        const robot = robotManager.getRobot(this.robotId);
+        return robot.drive(this.tileDistance);
+    }
+
+    public reverse(): DriveCommand {
+        return new DriveCommand(
+            this.robotId,
+            -this.tileDistance,
+        );
+    }
+}
+
+/**
  * Represents a robot translation in x and y.
  *
  * Note this may involve the robot turning first.

--- a/src/server/robot/robot.ts
+++ b/src/server/robot/robot.ts
@@ -1,4 +1,4 @@
-import { FULL_ROTATION, clampHeading } from "../utils/units";
+import { FULL_ROTATION, RADIAN, clampHeading } from "../utils/units";
 import { Position, ZERO_POSITION } from "./position";
 import { GridIndices } from "./grid-indices";
 import { tcpServer } from "../api/api";
@@ -39,7 +39,7 @@ export class Robot {
     }
 
     /**
-     * @param heading - An absolute heading to turn to.
+     * @param heading - An absolute heading to turn to, in degrees. 0 is up (from white to black).
      */
     public async absoluteRotate(heading: number): Promise<void> {
         const delta1: number = heading - this.heading;
@@ -56,7 +56,7 @@ export class Robot {
     }
 
     /**
-     * @param deltaHeading - A relative heading to turn by.
+     * @param deltaHeading - A relative heading to turn by, in degrees.
      */
     public async relativeRotate(deltaHeading: number): Promise<void> {
         this.heading = clampHeading(this.heading + deltaHeading);
@@ -68,21 +68,32 @@ export class Robot {
      * @param deltaPosition - The amount to offset the current position by.
      */
     public async relativeMove(deltaPosition: Position): Promise<void> {
-        // TODO: Compute drive arguments
-        const xOffset = deltaPosition.x - this.position.x;
-        const yOffset = deltaPosition.y - this.position.y;
-        const distance = Math.sqrt(xOffset * xOffset + yOffset * yOffset);
-        const promise = this.drive(distance);
+        const offset = deltaPosition.sub(this.position);
+        const distance = Math.hypot(offset.x, offset.y);
+        const angle = clampHeading(Math.atan2(-offset.x, offset.y)*RADIAN);
+        const promise = this.absoluteRotate(angle).then(() => this.drive(distance));
         this.position = this.position.add(deltaPosition);
         return promise;
     }
 
+    /**
+     * Send a packet to the robot indicating angle to turn. Returns a promise that finishes when the
+     * robot finishes the action.
+     *
+     * @param deltaHeading - A relative heading to turn by, in radians. May be positive or negative.
+     */
     public async turn(deltaHeading: number): Promise<void> {
         const tunnel = tcpServer.getTunnelFromId(this.id);
         tunnel.send({ type: "TURN_BY_ANGLE", deltaHeading });
         return tunnel.waitForActionResponse();
     }
 
+    /**
+     * Send a packet to the robot indicating distance to drive. Returns a promise that finishes when the
+     * robot finishes the action.
+     *
+     * @param tileDistance - The distance to drive forward or backwards by. 1 is defined as the length of a tile.
+     */
     public async drive(tileDistance: number): Promise<void> {
         const tunnel = tcpServer.getTunnelFromId(this.id);
         tunnel.send({ type: "DRIVE_TILES", tileDistance });

--- a/src/server/robot/robot.ts
+++ b/src/server/robot/robot.ts
@@ -70,8 +70,10 @@ export class Robot {
     public async relativeMove(deltaPosition: Position): Promise<void> {
         const offset = deltaPosition.sub(this.position);
         const distance = Math.hypot(offset.x, offset.y);
-        const angle = clampHeading(Math.atan2(-offset.x, offset.y)*RADIAN);
-        const promise = this.absoluteRotate(angle).then(() => this.drive(distance));
+        const angle = clampHeading(Math.atan2(-offset.x, offset.y) * RADIAN);
+        const promise = this.absoluteRotate(angle).then(() =>
+            this.drive(distance),
+        );
         this.position = this.position.add(deltaPosition);
         return promise;
     }


### PR DESCRIPTION
Partially reverts #187 to restore the RelativeMove behavior of turning and driving, as the RelativeMove is intended to get a robot between two Positions, not to just drive. To fix this, a new command `DriveCommand` is created to be used for only driving instead.